### PR TITLE
Merge environments into prepared request

### DIFF
--- a/veracode/API/admin.py
+++ b/veracode/API/admin.py
@@ -7,8 +7,8 @@ class DeleteUser(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(DeleteUser, self).__init__('deleteuser.do', 3.0)
+    def __init__(self, **kwargs):
+        super(DeleteUser, self).__init__('deleteuser.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -22,8 +22,8 @@ class UpdateUser(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(UpdateUser, self).__init__('updateuser.do', 3.0)
+    def __init__(self, **kwargs):
+        super(UpdateUser, self).__init__('updateuser.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -37,8 +37,8 @@ class GetTrackList(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetTrackList, self).__init__('gettracklist.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GetTrackList, self).__init__('gettracklist.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -52,8 +52,8 @@ class GetMaintenanceScheduleInfo(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetMaintenanceScheduleInfo, self).__init__('getmaintenancescheduleinfo.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GetMaintenanceScheduleInfo, self).__init__('getmaintenancescheduleinfo.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -67,8 +67,8 @@ class GetTeamList(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetTeamList, self).__init__('getteamlist.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GetTeamList, self).__init__('getteamlist.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -82,8 +82,8 @@ class GetUserInfo(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetUserInfo, self).__init__('getuserinfo.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GetUserInfo, self).__init__('getuserinfo.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -97,8 +97,8 @@ class DeleteTeam(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(DeleteTeam, self).__init__('deleteteam.do', 3.0)
+    def __init__(self, **kwargs):
+        super(DeleteTeam, self).__init__('deleteteam.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -112,8 +112,8 @@ class CreateUser(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(CreateUser, self).__init__('createuser.do', 3.0)
+    def __init__(self, **kwargs):
+        super(CreateUser, self).__init__('createuser.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -127,8 +127,8 @@ class GetUserList(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetUserList, self).__init__('getuserlist.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GetUserList, self).__init__('getuserlist.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -142,8 +142,8 @@ class GetTeamInfo(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetTeamInfo, self).__init__('getteaminfo.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GetTeamInfo, self).__init__('getteaminfo.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -157,8 +157,8 @@ class GetCurricumList(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetCurricumList, self).__init__('getcurricumlist.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GetCurricumList, self).__init__('getcurricumlist.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -172,8 +172,8 @@ class CreateTeam(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(CreateTeam, self).__init__('createteam.do', 3.0)
+    def __init__(self, **kwargs):
+        super(CreateTeam, self).__init__('createteam.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -187,8 +187,8 @@ class UpdateTeam(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(UpdateTeam, self).__init__('updateteam.do', 3.0)
+    def __init__(self, **kwargs):
+        super(UpdateTeam, self).__init__('updateteam.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):

--- a/veracode/API/core.py
+++ b/veracode/API/core.py
@@ -34,7 +34,12 @@ class REST(object):
         request = requests.Request(method, self.__server, params=query,
                 files=file, auth=RequestsAuthPluginVeracodeHMAC())
         prepared_request = request.prepare()
-        res = session.send(prepared_request)
+
+        # Merge environment settings into session
+        # This allows things like, REQUESTS_CA_BUNDLE, to be used
+        settings = session.merge_environment_settings(
+                prepared_request.url, {}, None, None, None)
+        res = session.send(prepared_request, **settings)
 
         logger.debug('{}, {}, COMPLETED'.format(self.__end_point, query))
         logger.info('request URL: {}'.format(res.request.path_url))

--- a/veracode/API/flawreport.py
+++ b/veracode/API/flawreport.py
@@ -7,8 +7,8 @@ class GenerateFlawReport(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GenerateFlawReport, self).__init__('generateflawreport.do', 3.0)
+    def __init__(self, **kwargs):
+        super(GenerateFlawReport, self).__init__('generateflawreport.do', 3.0, **kwargs)
 
     @classmethod
     def get(self, **args):

--- a/veracode/API/mitigation.py
+++ b/veracode/API/mitigation.py
@@ -7,8 +7,8 @@ class GetMinigationInfo(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetMinigationInfo, self).__init__('getminigationinfo.do', None)
+    def __init__(self, **kwargs):
+        super(GetMinigationInfo, self).__init__('getminigationinfo.do', None, **kwargs)
 
     @classmethod
     def get(self, **args):

--- a/veracode/API/results.py
+++ b/veracode/API/results.py
@@ -7,8 +7,8 @@ class ThirdPartyReportPDF(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(ThirdPartyReportPDF, self).__init__('thirdpartyreportpdf.do', 4.0)
+    def __init__(self, **kwargs):
+        super(ThirdPartyReportPDF, self).__init__('thirdpartyreportpdf.do', 4.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -22,8 +22,8 @@ class GetAccountCustomFieldList(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetAccountCustomFieldList, self).__init__('getaccountcustomfieldlist.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetAccountCustomFieldList, self).__init__('getaccountcustomfieldlist.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -37,8 +37,8 @@ class DetailedReport(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(DetailedReport, self).__init__('detailedreport.do', 5.0)
+    def __init__(self, **kwargs):
+        super(DetailedReport, self).__init__('detailedreport.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -52,8 +52,8 @@ class GetAppBuilds(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetAppBuilds, self).__init__('getappbuilds.do', 4.0)
+    def __init__(self, **kwargs):
+        super(GetAppBuilds, self).__init__('getappbuilds.do', 4.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -67,8 +67,8 @@ class SummaryReport(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(SummaryReport, self).__init__('summaryreport.do', 4.0)
+    def __init__(self, **kwargs):
+        super(SummaryReport, self).__init__('summaryreport.do', 4.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -82,8 +82,8 @@ class DetailedReportPDF(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(DetailedReportPDF, self).__init__('detailedreportpdf.do', 5.0)
+    def __init__(self, **kwargs):
+        super(DetailedReportPDF, self).__init__('detailedreportpdf.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -97,8 +97,8 @@ class SummaryReportPDF(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(SummaryReportPDF, self).__init__('summaryreportpdf.do', 4.0)
+    def __init__(self, **kwargs):
+        super(SummaryReportPDF, self).__init__('summaryreportpdf.do', 4.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -112,8 +112,8 @@ class GetCallStacks(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetCallStacks, self).__init__('getcallstacks.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetCallStacks, self).__init__('getcallstacks.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):

--- a/veracode/API/sandbox.py
+++ b/veracode/API/sandbox.py
@@ -7,8 +7,8 @@ class UpdateSandbox(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(UpdateSandbox, self).__init__('updatesandbox.do', 5.0)
+    def __init__(self, **kwargs):
+        super(UpdateSandbox, self).__init__('updatesandbox.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -22,8 +22,8 @@ class CreateSandbox(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(CreateSandbox, self).__init__('createsandbox.do', 5.0)
+    def __init__(self, **kwargs):
+        super(CreateSandbox, self).__init__('createsandbox.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -37,8 +37,8 @@ class GetSandboxList(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetSandboxList, self).__init__('getsandboxlist.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetSandboxList, self).__init__('getsandboxlist.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -52,8 +52,8 @@ class PromoteSandbox(REST):
         
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(PromoteSandbox, self).__init__('promotesandbox.do', 5.0)
+    def __init__(self, **kwargs):
+        super(PromoteSandbox, self).__init__('promotesandbox.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):

--- a/veracode/API/upload.py
+++ b/veracode/API/upload.py
@@ -7,8 +7,8 @@ class GetAppList(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetAppList, self).__init__('getapplist.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetAppList, self).__init__('getapplist.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -22,8 +22,8 @@ class UpdateBuild(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(UpdateBuild, self).__init__('updatebuild.do', 5.0)
+    def __init__(self, **kwargs):
+        super(UpdateBuild, self).__init__('updatebuild.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -37,8 +37,8 @@ class DeleteBuild(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(DeleteBuild, self).__init__('deletebuild.do', 5.0)
+    def __init__(self, **kwargs):
+        super(DeleteBuild, self).__init__('deletebuild.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -52,8 +52,8 @@ class GetBuildInfo(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetBuildInfo, self).__init__('getbuildinfo.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetBuildInfo, self).__init__('getbuildinfo.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -67,8 +67,8 @@ class GetAppInfo(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetAppInfo, self).__init__('getappinfo.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetAppInfo, self).__init__('getappinfo.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -82,8 +82,8 @@ class GetPolicyList(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetPolicyList, self).__init__('getpolicylist.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetPolicyList, self).__init__('getpolicylist.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -97,8 +97,8 @@ class BeginPrescan(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(BeginPrescan, self).__init__('beginprescan.do', 5.0)
+    def __init__(self, **kwargs):
+        super(BeginPrescan, self).__init__('beginprescan.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -112,8 +112,8 @@ class UploadLargeFile(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(UploadLargeFile, self).__init__('uploadlargefile.do', 5.0)
+    def __init__(self, **kwargs):
+        super(UploadLargeFile, self).__init__('uploadlargefile.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -127,8 +127,8 @@ class GetVendorList(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetVendorList, self).__init__('getvendorlist.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetVendorList, self).__init__('getvendorlist.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -142,8 +142,8 @@ class UpdateApp(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(UpdateApp, self).__init__('updateapp.do', 5.0)
+    def __init__(self, **kwargs):
+        super(UpdateApp, self).__init__('updateapp.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -157,8 +157,8 @@ class GetFileList(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetFileList, self).__init__('getfilelist.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetFileList, self).__init__('getfilelist.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -172,8 +172,8 @@ class CreateBuild(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(CreateBuild, self).__init__('createbuild.do', 5.0)
+    def __init__(self, **kwargs):
+        super(CreateBuild, self).__init__('createbuild.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -187,8 +187,8 @@ class GetPreScanResults(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetPreScanResults, self).__init__('getprescanresults.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetPreScanResults, self).__init__('getprescanresults.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -202,8 +202,8 @@ class CreateApp(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(CreateApp, self).__init__('createapp.do', 5.0)
+    def __init__(self, **kwargs):
+        super(CreateApp, self).__init__('createapp.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -217,8 +217,8 @@ class GetBuildList(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(GetBuildList, self).__init__('getbuildlist.do', 5.0)
+    def __init__(self, **kwargs):
+        super(GetBuildList, self).__init__('getbuildlist.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -232,8 +232,8 @@ class UploadFile(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(UploadFile, self).__init__('uploadfile.do', 5.0)
+    def __init__(self, **kwargs):
+        super(UploadFile, self).__init__('uploadfile.do', 5.0, **kwargs)
 
     @classmethod
     def post(self, **args):
@@ -249,8 +249,8 @@ class BeginScan(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(BeginScan, self).__init__('beginscan.do', 5.0)
+    def __init__(self, **kwargs):
+        super(BeginScan, self).__init__('beginscan.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -263,8 +263,8 @@ class RemoveFile(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(RemoveFile, self).__init__('removefile.do', 5.0)
+    def __init__(self, **kwargs):
+        super(RemoveFile, self).__init__('removefile.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):
@@ -278,8 +278,8 @@ class DeleteApp(REST):
 
         returns: XML data from veracode API
     """
-    def __init__(self, args=None):
-        super(DeleteApp, self).__init__('deleteapp.do', 5.0)
+    def __init__(self, **kwargs):
+        super(DeleteApp, self).__init__('deleteapp.do', 5.0, **kwargs)
 
     @classmethod
     def get(self, **args):


### PR DESCRIPTION
From the requests documentation: https://requests.readthedocs.io/en/master/user/advanced/#prepared-requests
Using Prepared Requests loses environment information, which can break things like using self-signed certificates through the supported REQUESTS_CA_BUNDLE variable. This change re-adds this information into the context of the request.

Additionally, this work enables values to be passed through to the underlying REST object, should it need to be configured further. One important setting allows the target server of the API calls to be changed, which enables better testing.